### PR TITLE
Initialize basic backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # TimeSheetSite
+
+This repository contains a simple time tracking application with a .NET 8 backend and a Vue.js frontend.
+
+## Backend
+
+The API project is located in `TimeSheetApi` and uses:
+
+- ASP.NET Core 8
+- EF Core with SQL Server
+- Controller based API returning JSON via `System.Text.Json`
+
+To run the backend:
+
+```bash
+cd TimeSheetApi
+dotnet run
+```
+
+## Frontend
+
+The frontend is a minimal Vue 3 app powered by Vite. To start the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Database
+
+The connection string is configured in `TimeSheetApi/appsettings.json`. By default it uses the local SQL Server instance `(localdb)`.

--- a/TimeSheetApi/Controllers/EmployeesController.cs
+++ b/TimeSheetApi/Controllers/EmployeesController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TimeSheetApi.Models;
+
+namespace TimeSheetApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class EmployeesController(TimeSheetContext context) : ControllerBase
+{
+    private readonly TimeSheetContext _context = context;
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Employee>>> Get() =>
+        await _context.Employees.ToListAsync();
+
+    [HttpPost]
+    public async Task<ActionResult<Employee>> Post(Employee employee)
+    {
+        _context.Employees.Add(employee);
+        await _context.SaveChangesAsync();
+        return CreatedAtAction(nameof(Get), new { id = employee.Id }, employee);
+    }
+}

--- a/TimeSheetApi/Controllers/ProjectsController.cs
+++ b/TimeSheetApi/Controllers/ProjectsController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TimeSheetApi.Models;
+
+namespace TimeSheetApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ProjectsController(TimeSheetContext context) : ControllerBase
+{
+    private readonly TimeSheetContext _context = context;
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Project>>> Get() =>
+        await _context.Projects.ToListAsync();
+
+    [HttpPost]
+    public async Task<ActionResult<Project>> Post(Project project)
+    {
+        _context.Projects.Add(project);
+        await _context.SaveChangesAsync();
+        return CreatedAtAction(nameof(Get), new { id = project.Id }, project);
+    }
+}

--- a/TimeSheetApi/Controllers/TimeEntriesController.cs
+++ b/TimeSheetApi/Controllers/TimeEntriesController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TimeSheetApi.Models;
+
+namespace TimeSheetApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class TimeEntriesController(TimeSheetContext context) : ControllerBase
+{
+    private readonly TimeSheetContext _context = context;
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<TimeEntry>>> Get()
+    {
+        return await _context.TimeEntries
+            .Include(t => t.Employee)
+            .Include(t => t.Project)
+            .ToListAsync();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<TimeEntry>> Post(TimeEntry entry)
+    {
+        _context.TimeEntries.Add(entry);
+        await _context.SaveChangesAsync();
+        return CreatedAtAction(nameof(Get), new { id = entry.Id }, entry);
+    }
+}

--- a/TimeSheetApi/Models/Employee.cs
+++ b/TimeSheetApi/Models/Employee.cs
@@ -1,0 +1,7 @@
+namespace TimeSheetApi.Models;
+
+public class Employee
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/TimeSheetApi/Models/Project.cs
+++ b/TimeSheetApi/Models/Project.cs
@@ -1,0 +1,8 @@
+namespace TimeSheetApi.Models;
+
+public class Project
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal HourlyRate { get; set; }
+}

--- a/TimeSheetApi/Models/TimeEntry.cs
+++ b/TimeSheetApi/Models/TimeEntry.cs
@@ -1,0 +1,12 @@
+namespace TimeSheetApi.Models;
+
+public class TimeEntry
+{
+    public int Id { get; set; }
+    public int EmployeeId { get; set; }
+    public Employee? Employee { get; set; }
+    public int ProjectId { get; set; }
+    public Project? Project { get; set; }
+    public DateTime Date { get; set; }
+    public decimal Hours { get; set; }
+}

--- a/TimeSheetApi/Models/TimeSheetContext.cs
+++ b/TimeSheetApi/Models/TimeSheetContext.cs
@@ -1,0 +1,10 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace TimeSheetApi.Models;
+
+public class TimeSheetContext(DbContextOptions<TimeSheetContext> options) : DbContext(options)
+{
+    public DbSet<Employee> Employees => Set<Employee>();
+    public DbSet<Project> Projects => Set<Project>();
+    public DbSet<TimeEntry> TimeEntries => Set<TimeEntry>();
+}

--- a/TimeSheetApi/Program.cs
+++ b/TimeSheetApi/Program.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using TimeSheetApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers().AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddDbContext<TimeSheetContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();
+

--- a/TimeSheetApi/Properties/launchSettings.json
+++ b/TimeSheetApi/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:12610",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5165",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/TimeSheetApi/TimeSheetApi.csproj
+++ b/TimeSheetApi/TimeSheetApi.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/TimeSheetApi/TimeSheetApi.http
+++ b/TimeSheetApi/TimeSheetApi.http
@@ -1,0 +1,6 @@
+@TimeSheetApi_HostAddress = http://localhost:5165
+
+GET {{TimeSheetApi_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/TimeSheetApi/appsettings.Development.json
+++ b/TimeSheetApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/TimeSheetApi/appsettings.json
+++ b/TimeSheetApi/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=TimeSheetDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/TimeSheetSite.sln
+++ b/TimeSheetSite.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimeSheetApi", "TimeSheetApi\TimeSheetApi.csproj", "{B8A96B69-86E0-4D62-9FBB-B00A9C94A87E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B8A96B69-86E0-4D62-9FBB-B00A9C94A87E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8A96B69-86E0-4D62-9FBB-B00A9C94A87E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8A96B69-86E0-4D62-9FBB-B00A9C94A87E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8A96B69-86E0-4D62-9FBB-B00A9C94A87E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TimeSheet App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "timesheet-frontend",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "@vitejs/plugin-vue": "^5.0.0"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,9 @@
+<template>
+  <h1>TimeSheet App</h1>
+</template>
+
+<script setup>
+</script>
+
+<style>
+</style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()]
+})


### PR DESCRIPTION
## Summary
- scaffold ASP.NET Core 8 Web API with controller-based endpoints and EF Core
- add models for employees, projects, and time entries
- configure DbContext with SQL Server connection
- provide minimal Vue 3 frontend using Vite
- update README with build instructions

## Testing
- `dotnet build TimeSheetSite.sln`
- `dotnet run --project TimeSheetApi` (started and stopped successfully)

------
https://chatgpt.com/codex/tasks/task_e_6856cca755008323a9197db7dd03ef21