### PR TITLE
Add basic employee management UI

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -26,12 +26,14 @@
 
   <h2>Project Report</h2>
   <ProjectReport />
+  <EmployeeManager />
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
 import TimeEntryForm from './components/TimeEntryForm.vue'
 import ProjectReport from './components/ProjectReport.vue'
+import EmployeeManager from './components/EmployeeManager.vue'
 
 const entries = ref([])
 

--- a/frontend/src/components/EmployeeManager.vue
+++ b/frontend/src/components/EmployeeManager.vue
@@ -1,0 +1,75 @@
+<template>
+  <div>
+    <h2>Employees</h2>
+    <form @submit.prevent="addEmployee">
+      <label>
+        Name
+        <input v-model="employee.name" required />
+      </label>
+      <label>
+        Hourly Rate
+        <input type="number" step="0.01" v-model.number="employee.hourlyRate" required />
+      </label>
+      <button type="submit">Add</button>
+    </form>
+    <table v-if="employees.length">
+      <thead>
+        <tr>
+          <th>Id</th>
+          <th>Name</th>
+          <th>Hourly Rate</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="e in employees" :key="e.id">
+          <td>{{ e.id }}</td>
+          <td>{{ e.name }}</td>
+          <td>{{ e.hourlyRate }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const employees = ref([])
+const employee = ref({ name: '', hourlyRate: 0 })
+
+async function load() {
+  employees.value = await fetch('/api/employees').then(r => r.json())
+}
+
+async function addEmployee() {
+  await fetch('/api/employees', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(employee.value)
+  })
+  employee.value = { name: '', hourlyRate: 0 }
+  load()
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+label {
+  display: flex;
+  flex-direction: column;
+}
+table {
+  border-collapse: collapse;
+}
+th, td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add an `EmployeeManager` vue component for listing and creating employees
- show the employee manager in the main application

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856d9c9985083239525bd00e513b3ed