### PR TITLE
Fix API 500 by switching to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,3 +405,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 frontend/dist/
+TimeSheetApi/timesheet.db

--- a/TimeSheetApi/Program.cs
+++ b/TimeSheetApi/Program.cs
@@ -13,9 +13,15 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddDbContext<TimeSheetContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<TimeSheetContext>();
+    db.Database.EnsureCreated();
+}
 
 if (app.Environment.IsDevelopment())
 {

--- a/TimeSheetApi/TimeSheetApi.csproj
+++ b/TimeSheetApi/TimeSheetApi.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/TimeSheetApi/appsettings.json
+++ b/TimeSheetApi/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=TimeSheetDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Data Source=timesheet.db"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- use SQLite instead of LocalDB
- ensure DB is created on startup
- ignore generated database file

## Testing
- `dotnet build TimeSheetSite.sln`

------
https://chatgpt.com/codex/tasks/task_e_6856e032ecc88323a773f68f729cc746