### PR TITLE
Fix frontend proxy port

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [vue()],
   server: {
     proxy: {
-      '/api': 'http://localhost:5000'
+      '/api': 'http://localhost:5165'
     }
   }
 })


### PR DESCRIPTION
## Summary
- fix Vite proxy to backend API port

## Testing
- `npm run build`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6856e3262c948323a5d8ab483a974262