### PR TITLE
Fix SQLite schema mismatch

### DIFF
--- a/TimeSheetApi/Program.cs
+++ b/TimeSheetApi/Program.cs
@@ -20,6 +20,7 @@ var app = builder.Build();
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<TimeSheetContext>();
+    db.Database.EnsureDeleted();
     db.Database.EnsureCreated();
 }
 


### PR DESCRIPTION
## Summary
- recreate the SQLite database each time the API starts

## Testing
- `dotnet build -v q` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856ecce6fc48323906b1d7bdc18b91e