### PR TITLE
Fix POST requests failing due to null ids

### DIFF
--- a/frontend/src/components/CustomerManager.vue
+++ b/frontend/src/components/CustomerManager.vue
@@ -61,10 +61,12 @@ function editCustomer(c) {
 async function saveCustomer() {
   const url = editingId.value ? `/api/customers/${editingId.value}` : '/api/customers'
   const method = editingId.value ? 'PUT' : 'POST'
+  const payload = { ...newCustomer.value }
+  if (editingId.value !== null) payload.id = editingId.value
   await fetch(url, {
     method,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...newCustomer.value, id: editingId.value })
+    body: JSON.stringify(payload)
   })
   cancelEdit()
   load()

--- a/frontend/src/components/EmployeeManager.vue
+++ b/frontend/src/components/EmployeeManager.vue
@@ -56,10 +56,12 @@ function editEmployee(e) {
 async function saveEmployee() {
   const url = editingId.value ? `/api/employees/${editingId.value}` : '/api/employees'
   const method = editingId.value ? 'PUT' : 'POST'
+  const payload = { ...employee.value }
+  if (editingId.value !== null) payload.id = editingId.value
   await fetch(url, {
     method,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...employee.value, id: editingId.value })
+    body: JSON.stringify(payload)
   })
   cancelEdit()
   load()

--- a/frontend/src/components/ProjectManager.vue
+++ b/frontend/src/components/ProjectManager.vue
@@ -79,10 +79,12 @@ function editProject(p) {
 async function saveProject() {
   const url = editingId.value ? `/api/projects/${editingId.value}` : '/api/projects'
   const method = editingId.value ? 'PUT' : 'POST'
+  const payload = { ...project.value }
+  if (editingId.value !== null) payload.id = editingId.value
   await fetch(url, {
     method,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...project.value, id: editingId.value })
+    body: JSON.stringify(payload)
   })
   cancelEdit()
   load()


### PR DESCRIPTION
## Summary
- avoid sending a null `id` when creating customers
- avoid sending a null `id` when creating employees
- avoid sending a null `id` when creating projects

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test --prefix frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856f3168a508323ad0c832b03d8dffa