### PR TITLE
Add xUnit tests

### DIFF
--- a/TimeSheetApi.Tests/CustomersControllerTests.cs
+++ b/TimeSheetApi.Tests/CustomersControllerTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using TimeSheetApi.Controllers;
+using TimeSheetApi.Models;
+
+namespace TimeSheetApi.Tests;
+
+public class CustomersControllerTests
+{
+    [Fact]
+    public async Task Get_Returns_All_Customers()
+    {
+        var options = new DbContextOptionsBuilder<TimeSheetContext>()
+            .UseInMemoryDatabase(databaseName: "CustomersTestDb")
+            .Options;
+
+        using var context = new TimeSheetContext(options);
+        context.Customers.Add(new Customer { Id = 1, Name = "Acme" });
+        await context.SaveChangesAsync();
+
+        var controller = new CustomersController(context);
+        var result = await controller.Get();
+
+        Assert.Single(result.Value!);
+        Assert.Equal("Acme", result.Value!.First().Name);
+    }
+}

--- a/TimeSheetApi.Tests/GlobalUsings.cs
+++ b/TimeSheetApi.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/TimeSheetApi.Tests/TimeSheetApi.Tests.csproj
+++ b/TimeSheetApi.Tests/TimeSheetApi.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TimeSheetApi\TimeSheetApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TimeSheetSite.sln
+++ b/TimeSheetSite.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimeSheetApi", "TimeSheetApi\TimeSheetApi.csproj", "{B8A96B69-86E0-4D62-9FBB-B00A9C94A87E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimeSheetApi.Tests", "TimeSheetApi.Tests\TimeSheetApi.Tests.csproj", "{B12E7170-D132-426F-9B97-9AFB7AFD6A93}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{B8A96B69-86E0-4D62-9FBB-B00A9C94A87E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B8A96B69-86E0-4D62-9FBB-B00A9C94A87E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8A96B69-86E0-4D62-9FBB-B00A9C94A87E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B12E7170-D132-426F-9B97-9AFB7AFD6A93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B12E7170-D132-426F-9B97-9AFB7AFD6A93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B12E7170-D132-426F-9B97-9AFB7AFD6A93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B12E7170-D132-426F-9B97-9AFB7AFD6A93}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add xUnit test project for the API
- register test project in solution
- test basic customer retrieval logic

## Testing
- `dotnet test TimeSheetApi.Tests/TimeSheetApi.Tests.csproj --no-build -v m`

------
https://chatgpt.com/codex/tasks/task_e_685768a736d88323bc5301fc02e6a741